### PR TITLE
Wrap datadir fixture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ pysam = "^0.15"
 xphyle = "^4.0.8"
 
 [tool.poetry.dev-dependencies]
-pytest = "^3.0"
+pytest = "^4.0"
 pytest-cov = "^2.7"
-black = {version = "^18.9b0",allows-prereleases = true}
+black = {version = "^19.3b0",allows-prereleases = true}
 pytest-datadir-ng = "^1.1"
 
 [tool.poetry.extras]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import pytest
+
+
+class DataPath(object):
+    def __init__(self, datadir_obj):
+        self.datadir_obj = datadir_obj
+
+    def __getitem__(self, path):
+        pypath = self.datadir_obj[path]
+        return Path(pypath)
+
+
+@pytest.fixture
+def datapath(datadir):
+    return DataPath(datadir)
+
+
+@pytest.fixture
+def datapath_copy(datadir_copy):
+    return DataPath(datadir_copy)

--- a/tests/test_integration_partition.py
+++ b/tests/test_integration_partition.py
@@ -21,7 +21,7 @@ def test_partition_index_w_contigs(
     contig_sizes_file,
     partition_count,
     expected_partition_bed,
-    datadir,
+    datapath,
     request,
     tmp_path,
 ):
@@ -35,9 +35,9 @@ def test_partition_index_w_contigs(
     ```
     """
     # Arrange input datafiles
-    index_file = datadir[index_file]
-    contig_sizes_file = datadir[contig_sizes_file]
-    expected_partition_bed = datadir[expected_partition_bed]
+    index_file = datapath[index_file]
+    contig_sizes_file = datapath[contig_sizes_file]
+    expected_partition_bed = datapath[expected_partition_bed]
 
     partition_bed = tmp_path / "{}.partitions.bed".format(request.node.name)
 


### PR DESCRIPTION
**Motivation**

When working on other issues people encountered a seemingly random failure in `xphyle`. After looking into it turns out the `datadir` fixture was returning `py.path.local` objects which were ultimately unexpected in `xphyle`.

**Changes**

* Defined 2 new fixtures `datapath` and `datapath_copy` that do the same thing as the `datadir` counterparts, but just make sure to return `pathlib.Path` objects.

* Opportunistic update of `pytest` and `black` dependency major versions.