### PR TITLE
Replace InterLap with cgranges

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ all:
 	$(TEST)
 
 install:
-	cd cgranges && python setup.py bdist_wheel
 	$(BUILD)
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ all:
 	$(TEST)
 
 install:
+	cd cgranges && python setup.py bdist_wheel
 	$(BUILD)
 
 test:

--- a/indextools/intervals.py
+++ b/indextools/intervals.py
@@ -388,7 +388,8 @@ class GenomeInterval(Sized):
 
 class Intervals:
     """
-    Collection of InterLaps (one per contig).
+    Wrapper around a cranges that also stores `GenomeInterval`s by their
+    (chromsome, start, end).
 
     Args:
         intervals: Iterable of GenomeIntervals.
@@ -426,7 +427,7 @@ class Intervals:
             self._cr.add(*key)
             self._intervals[key] = interval
 
-    def close(self):
+    def close(self) -> None:
         if not self.closed:
             self._cr.index()
             self._closed = True
@@ -440,6 +441,9 @@ class Intervals:
 
         Args:
             interval: The interval to search.
+
+        Returns:
+            An iterator over the overlapping intervals.
         """
         if not self.closed:
             raise RuntimeError("Cannot call 'find()' before calling 'close()'.")

--- a/indextools/intervals.py
+++ b/indextools/intervals.py
@@ -1,9 +1,6 @@
 from collections import Sized
 import copy
 from enum import IntFlag
-import functools
-import itertools
-import operator
 from typing import (
     Iterable,
     Iterator,
@@ -16,9 +13,8 @@ from typing import (
     cast,
 )
 
-from indextools.utils import OrderedSet
-
 from ngsindex.utils import DefaultDict
+from quicksect import Interval, IntervalTree
 
 
 BGZF_BLOCK_SIZE = 2 ** 16
@@ -47,7 +43,7 @@ BED3 = Tuple[str, int, int]
 BED6 = Tuple[str, int, int, str, int, str]
 
 
-class GenomeInterval(Sized):
+class GenomeInterval(Interval, Sized):
     """
     An interval of a contig, consisting of a contig name, start position (
     zero-indexed), and end position (non-inclusive).
@@ -68,9 +64,8 @@ class GenomeInterval(Sized):
             start = 0
         if end <= start:
             raise ValueError(f"'end' must be >= 'start'; {end} <= {start}")
+        super().__init__(start, end)
         self.contig = contig
-        self.start = start
-        self.end = end
         self.annotations = kwargs
 
     @property
@@ -397,319 +392,41 @@ class Intervals:
 
     Args:
         intervals: Iterable of GenomeIntervals.
-        interval_type: Type of Interval that will be added. If None, is
-            auto-detected from the first interval that is added.
-        allows_overlapping: Whether overlapping intervals can be added,
-            or if overlapping intervals are merged.
     """
 
-    def __init__(
-        self,
-        intervals: Iterable[GenomeInterval] = (),
-        interval_type: Type[GenomeInterval] = None,
-        allows_overlapping: bool = True,
-    ) -> None:
-        if interval_type is None:
-            if intervals:
-                intervals = list(intervals)
-                interval_type = type(intervals[0])
-            else:
-                raise ValueError(
-                    "Either 'interval_type' or 'intervals' must be specified."
-                )
-        self.interval_type = interval_type
-        self.interlaps = DefaultDict(
-            default=functools.partial(
-                InterLap,
-                interval_type=interval_type,
-                allows_overlapping=allows_overlapping,
-            )
-        )
+    def __init__(self, intervals: Optional[Iterable[GenomeInterval]] = None):
+        self.interval_trees = DefaultDict(default=IntervalTree)
         if intervals:
             self.add_all(intervals)
 
-    @property
-    def contigs(self) -> Sequence[str]:
-        return tuple(self.interlaps.keys())
-
     def add_all(self, intervals: Iterable[GenomeInterval]) -> None:
         """Add all intervals from an iterable of GenomeIntervals.
+
+        Args:
+            intervals: The intervals to add.
         """
-        modified = set()
         for interval in intervals:
-            self.interlaps[interval.contig].add(interval)
-            modified.add(interval.contig)
-        for contig in modified:
-            self.interlaps[contig].commit()
+            self.interval_trees[interval.contig].insert(interval)
+
+    @property
+    def contigs(self) -> Sequence[str]:
+        return tuple(self.interval_trees.keys())
+
+    def __contains__(self, contig: str) -> bool:
+        return contig in self.interval_trees
+
+    def get(self, contig: str) -> IntervalTree:
+        if contig not in self:
+            raise ValueError("Contig not found: {}".format(contig))
+        return self.interval_trees[contig]
 
     def find(self, interval: GenomeInterval) -> Iterator[GenomeInterval]:
         """Find intervals that overlap `interval`.
-        """
-        contig = interval.contig
-        if contig not in self.interlaps:
-            return
-        yield from self.interlaps[contig].find(interval)
-
-    def intersect(self, interval: GenomeInterval) -> Iterator[GenomeInterval]:
-        """Iterate over intersections with `interval`. Intersection is like
-        find except that the yielded intervals include only the intersected
-        portions.
-        """
-        contig = interval.contig
-        if contig not in self.interlaps:
-            return
-        yield from self.interlaps[contig].intersect(interval)
-
-    def intersect_all(
-        self, intervals: Iterable[GenomeInterval]
-    ) -> Iterator[GenomeInterval]:
-        """Iterate over intersections with all `intervals`.
-        """
-        intersections = OrderedSet()
-        for ivl in intervals:
-            intersections.update(self.intersect(ivl))
-        yield from intersections
-
-    def closest(
-        self, interval: GenomeInterval, side: int = Side.LEFT | Side.RIGHT
-    ) -> Iterator[GenomeInterval]:
-        """Find the closest interval(s) to `interval.
-        """
-        contig = interval.contig
-        if contig not in self.interlaps:
-            return
-        yield from self.interlaps[contig].closest(other=interval, side=side)
-
-    def __len__(self):
-        return sum(len(ilap) for ilap in self.interlaps.values())
-
-    def __contains__(self, interval: GenomeInterval) -> bool:
-        """Returns True if `interval` intersects any intervals.
-        """
-        contig = interval.contig
-        if contig not in self.interlaps:
-            return False
-        return interval in self.interlaps[contig]
-
-    def __iter__(self) -> Iterator[GenomeInterval]:
-        return itertools.chain(self.interlaps)
-
-
-class InterLap:
-    """Fast interval overlap testing. An InterLap is based on a sorted list
-    of intervals. Resorting the list is only performed when `commit` is called.
-    Overlap testing without first 'committing' any added intervals will probably
-    yield incorrect results.
-
-    Args:
-        interval_type: Type of Interval that will be added. If None, is
-            auto-detected from the first interval that is added.
-        allows_overlapping: Whether overlapping intervals can be added,
-            or if overlapping intervals are merged.
-
-    See:
-        Adapted from https://github.com/brentp/interlap.
-    """
-
-    def __init__(
-        self,
-        interval_type: Optional[Type[GenomeInterval]] = None,
-        allows_overlapping: bool = True,
-    ) -> None:
-        self.interval_type = interval_type
-        self.allows_overlapping = allows_overlapping
-        self._iset = []
-        self._maxlen = 0
-        self._dirty = False
-
-    def add(
-        self,
-        intervals: Union[GenomeInterval, Iterable[GenomeInterval]],
-        commit: Optional[bool] = None,
-    ):
-        """Add a single (or many) Intervals to the tree.
 
         Args:
-            intervals: An interval or sequence of intervals.
-            commit: Whether these additions should be immediately committed.
+            interval: The interval to search.
         """
-        if isinstance(intervals, GenomeInterval):
-            intervals = [intervals]
-        if self.interval_type is None:
-            self.interval_type = type(intervals[0])
-        if self.allows_overlapping:
-            self._iset.extend(intervals)
-            self._dirty = True
-            if commit:
-                self.commit()
-        elif commit is False:
-            raise ValueError(
-                "Cannot set commit=False for InterLaps in which overlapping "
-                "intervals are not allowed."
-            )
-        else:
-            if self._dirty:
-                self.commit()
-            for ivl in intervals:
-                overlapping = self.find(ivl)
-                if overlapping:
-                    ovl_list = list(overlapping)
-                    for overlapping_ivl in ovl_list:
-                        self._iset.remove(overlapping_ivl)
-                    ovl_list.append(ivl)
-                    ivl = GenomeInterval.merge(ovl_list)
-                self._iset.append(ivl)
-                self._resort()
-
-    def commit(self) -> None:
-        """Commit additions to this InterLap. This just means updating the
-        _maxlen attribute and resorting the _iset list.
-        """
-        if self._dirty:
-            self._resort()
-            self._dirty = False
-
-    def _resort(self):
-        self._iset.sort()
-        self._maxlen = max(len(r) for r in self._iset)
-
-    def __len__(self) -> int:
-        """Return number of intervals."""
-        return len(self._iset)
-
-    def __iter__(self) -> Iterator[GenomeInterval]:
-        return iter(self._iset)
-
-    def __contains__(self, other: GenomeInterval) -> bool:
-        """Indicate whether `other` overlaps any elements in the tree.
-        """
-        left = InterLap.binsearch_left_start(
-            self._iset, other.start - self._maxlen, 0, len(self._iset)
-        )
-        # Use a shortcut, since often the found interval will overlap.
-        max_search = 8
-        if left == len(self._iset):
-            return False
-        for left_ivl in self._iset[left:(left + max_search)]:
-            if left_ivl in other:
-                return True
-            if left_ivl.start > other.end:
-                return False
-
-        r = InterLap.binsearch_right_end(self._iset, other.end, 0, len(self._iset))
-        return any(s in other for s in self._iset[(left + max_search):r])
-
-    def find(self, other: GenomeInterval) -> Iterator[GenomeInterval]:
-        """Returns an iterable of elements that overlap `other` in the tree.
-        """
-        left = InterLap.binsearch_left_start(
-            self._iset, other.start - self._maxlen, 0, len(self._iset)
-        )
-        right = InterLap.binsearch_right_end(self._iset, other.end, 0, len(self._iset))
-        iopts = self._iset[left:right]
-        yield from (s for s in iopts if s in other)
-
-    def intersect(self, other: GenomeInterval) -> Iterator[GenomeInterval]:
-        """Like find, but the result is an iterable of new interval objects that
-        cover only the intersecting regions.
-        """
-        for ivl in self.find(other):
-            pos = sorted((ivl.start, ivl.end, other.start, other.end))
-            yield self.interval_type(ivl.contig, pos[1], pos[2])
-
-    def closest(
-        self, other: GenomeInterval, side: int = Side.LEFT | Side.RIGHT
-    ) -> Iterator[GenomeInterval]:
-        """Returns an iterable of the closest interval(s) to `other`.
-
-        Args:
-            other: The interval to search.
-            side: A bitwise combination of LEFT, RIGHT.
-
-        Yields:
-            If side == LEFT or RIGHT, the  single closest interval on the
-            specified side is yielded.  If side == LEFT | RIGHT, all intervals
-            that are equidistant on the left  and right side are yielded.
-        """
-        left = None
-        if side & Side.LEFT:
-            left = max(
-                0,
-                InterLap.binsearch_left_start(
-                    self._iset, other.start - self._maxlen, 0, len(self._iset)
-                )
-                - 1,
-            )
-
-        right = None
-        if side & Side.RIGHT:
-            right = min(
-                len(self._iset),
-                InterLap.binsearch_right_end(self._iset, other.end, 0, len(self._iset))
-                + 2,
-            )
-
-        if side == Side.LEFT | Side.RIGHT:
-            # Expand candidates to include all left intervals with the same end
-            # position and all right right intervals with the same start
-            # position as the nearest.
-
-            while left > 1 and self._iset[left].end == self._iset[left + 1].end:
-                left -= 1
-
-            while (
-                right < len(self._iset)
-                and self._iset[right - 1].start == self._iset[right].start
-            ):
-                right += 1
-
-            iopts = self._iset[left:right]
-            ovls = [s for s in iopts if s in other]
-            if ovls:
-                # Yield all candidate intervals that overlap `other`
-                yield from ovls
-            else:
-                #
-                iopts = sorted([(abs(i - other), i) for i in iopts])
-                _, g = next(iter(itertools.groupby(iopts, operator.itemgetter(0))))
-                for _, ival in g:
-                    yield ival
-        else:
-            if side == Side.LEFT:
-                ivl = self._iset[left]
-            else:
-                ivl = self._iset[right - 1]
-            if ivl != other:
-                yield ivl
-
-    @staticmethod
-    def binsearch_left_start(
-        intervals: Sequence[GenomeInterval], x: int, lo: int, hi: int
-    ) -> int:
-        """Like python's bisect_left, but finds the _lowest_ index where the value x
-        could be inserted to maintain order in the list intervals.
-        """
-        while lo < hi:
-            mid = (lo + hi) // 2
-            f = intervals[mid]
-            if f.start < x:
-                lo = mid + 1
-            else:
-                hi = mid
-        return lo
-
-    @staticmethod
-    def binsearch_right_end(
-        intervals: Sequence[GenomeInterval], x: int, lo: int, hi: int
-    ) -> int:
-        """Like python's bisect_right, but finds the _highest_ index where the value
-        x could be inserted to maintain order in the list intervals.
-        """
-        while lo < hi:
-            mid = (lo + hi) // 2
-            f = intervals[mid]
-            if x < f.start:
-                hi = mid
-            else:
-                lo = mid + 1
-        return lo
+        contig = interval.contig
+        if contig not in self:
+            return
+        yield from self.interval_trees[contig].find(interval)

--- a/indextools/regions.py
+++ b/indextools/regions.py
@@ -110,7 +110,7 @@ class Regions:
         targets: Optional[Path] = None,
         macros: Optional[Dict[str, List[str]]] = None,
     ) -> Intervals:
-        intervals = Intervals(allows_overlapping=False)
+        intervals = Intervals()
 
         if regions:
             intervals.add_all(self._create_interval(ivl) for ivl in regions)
@@ -169,51 +169,6 @@ class Regions:
             else:
                 raise ValueError(f"Contig {contig} not found in references")
         return GenomeInterval(contig, start, end)
-
-    def allows(self, interval: GenomeInterval) -> bool:
-        """
-
-        Args:
-            interval:
-
-        Returns:
-            True if 'interval' is fully contained within an included region (if any)
-            and does not overlap any excluded region (if any).
-        """
-
-        if self._include_intervals:
-            contained = False
-            overlapping = self._include_intervals.find(interval)
-            for ivl in overlapping:
-                if interval.compare(ivl)[2] == 1:
-                    contained = True
-        else:
-            contained = True
-
-        if not contained or (
-            self._exclude_intervals and interval in self._exclude_intervals
-        ):
-            return False
-
-        return True
-
-    def iter_allowed(self) -> Iterator[GenomeInterval]:
-        if self._include_intervals:
-            interval_itr = self._include_intervals
-        else:
-            interval_itr = (
-                GenomeInterval(ref, 0, self._references[ref])
-                for ref in self._references.names
-            )
-        if self._exclude_intervals:
-            for ivl in interval_itr:
-                overlapping = self._exclude_intervals.find(ivl)
-                if overlapping:
-                    yield from GenomeInterval.divide(ivl, overlapping)
-                else:
-                    yield ivl
-        else:
-            yield from interval_itr
 
     def intersect(self, intervals: Iterable[IVL]) -> Iterator[IVL]:
         """

--- a/indextools/utils.py
+++ b/indextools/utils.py
@@ -2,12 +2,8 @@ import os
 from pathlib import Path
 from typing import (
     Dict,
-    Generic,
-    Iterable,
-    Iterator,
     Sequence,
     Tuple,
-    TypeVar,
     Union,
     cast,
 )
@@ -18,31 +14,6 @@ from xphyle.utils import read_delimited
 
 class FileFormatError(Exception):
     pass
-
-
-T = TypeVar("T")
-
-
-class OrderedSet(Generic[T]):
-    """
-    Simple set (does not implement the full set API) based on dict that
-    maintains addition order.
-    """
-
-    def __init__(self, items: Iterable[T] = None) -> None:
-        self.items = {}
-        if items:
-            self.update(items)
-
-    def add(self, item: T) -> None:
-        self.items[item] = True
-
-    def update(self, items: Iterable[T]) -> None:
-        for item in items:
-            self.items[item] = True
-
-    def __iter__(self) -> Iterator[T]:
-        return iter(self.items.keys())
 
 
 class References:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ xphyle = "^4.0.8"
 [tool.poetry.dev-dependencies]
 pytest = "^4.0"
 pytest-cov = "^2.7"
-black = {version = "^19.3b0",allows-prereleases = true}
+black = {version = "^19.3b0", allows-prereleases = true}
 pytest-datadir-ng = "^1.1"
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ xphyle = "^4.0.8"
 [tool.poetry.dev-dependencies]
 pytest = "^4.0"
 pytest-cov = "^2.7"
-black = {version = "^19.3b0", allows-prereleases = true}
+black = {version = "^19.3b0",allows-prereleases = true}
 pytest-datadir-ng = "^1.1"
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ include = [
 [tool.poetry.dependencies]
 python = "^3.6"
 autoclick = "^0.6.0"
+cgranges = { git = "https://github.com/lh3/cgranges.git", branch = "master" }
 ngsindex = "^0.1.7"
 pysam = "^0.15"
 xphyle = "^4.0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ python = "^3.6"
 autoclick = "^0.6.0"
 ngsindex = "^0.1.7"
 pysam = "^0.15"
+quicksect = "^0.2.2"
 xphyle = "^4.0.8"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ python = "^3.6"
 autoclick = "^0.6.0"
 ngsindex = "^0.1.7"
 pysam = "^0.15"
-quicksect = "^0.2.2"
 xphyle = "^4.0.8"
 
 [tool.poetry.dev-dependencies]

--- a/tests/test_integration_partition.py
+++ b/tests/test_integration_partition.py
@@ -1,5 +1,4 @@
 from indextools.console import partition
-from pathlib import Path
 import filecmp
 import pytest
 

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -2,14 +2,21 @@ from indextools.intervals import Intervals, GenomeInterval
 
 
 def test_intervals():
-    intervals = Intervals()
-    intervals.add_all([
+    intervals = Intervals([
         GenomeInterval("chr1", 0, 10),
         GenomeInterval("chr1", 5, 15),
+        GenomeInterval("chr1", 10, 20),
         GenomeInterval("chr2", 3, 7)
     ])
+
     results = list(sorted(intervals.find(GenomeInterval("chr1", 3, 7))))
     assert len(results) == 2
     assert all(r.contig == "chr1" for r in results)
     assert results[0].as_bed3() == ("chr1", 0, 10)
     assert results[1].as_bed3() == ("chr1", 5, 15)
+
+    results = list(sorted(intervals.find(GenomeInterval("chr1", 10, 15))))
+    assert len(results) == 2
+    assert all(r.contig == "chr1" for r in results)
+    assert results[0].as_bed3() == ("chr1", 5, 15)
+    assert results[1].as_bed3() == ("chr1", 10, 20)

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -1,0 +1,15 @@
+from indextools.intervals import Intervals, GenomeInterval
+
+
+def test_intervals():
+    intervals = Intervals()
+    intervals.add_all([
+        GenomeInterval("chr1", 0, 10),
+        GenomeInterval("chr1", 5, 15),
+        GenomeInterval("chr2", 3, 7)
+    ])
+    results = list(sorted(intervals.find(GenomeInterval("chr1", 3, 7))))
+    assert len(results) == 2
+    assert all(r.contig == "chr1" for r in results)
+    assert results[0].as_bed3() == ("chr1", 0, 10)
+    assert results[1].as_bed3() == ("chr1", 5, 15)


### PR DESCRIPTION
The intervals code was originally based on [InterLap](https://github.com/brentp/interlap), which is fairly slow. I did some benchmarks and found [quicksect](https://github.com/brentp/quicksect) is a faster alternative (see #7). My fork of InterLap also had a bunch of extra code that wasn't being used anywhere. This PR removes the unused code and replaces InterLap with quicksect. The legacy InterLap code is here for posterity: https://gist.github.com/jdidion/70a4d4cef0fce70acf4d90321d1ad391