### PR TITLE
Make it clear that `contig_sizes` can be a file with more than two co…

### DIFF
--- a/indextools/console/partition.py
+++ b/indextools/console/partition.py
@@ -45,8 +45,8 @@ def partition(
             of volumes of child intervals).
         contig_sizes: A file with the sizes of all the contigs in the index;
             only necessary if the primary file is not specified, or if it does not
-            have sequence information in its header. This is a two-column tab-delimited
-            file ({contig_name}\t{contig_size}).
+            have sequence information in its header. This is a tab-delimited file
+            where the first two columns are ({contig_name}\t{contig_size}).
         regions: Regions to which the partitions are restricted.
         bgzip_outfile: Bgzip the output file. Set to False if 'outfile' is specified
             and it does not end with '.gz'.


### PR DESCRIPTION
…lumns (e.g. a faidx)